### PR TITLE
Stop invoking setup.py directly in build and packaging flows

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,14 +13,11 @@ PXDS = \
 	pxd/types.pxd \
 	pxd/zfs.pxd
 
-build: libzfs.c
-
-libzfs.c: libzfs.pyx ${PXIS} ${PXDS}
-	rm -f libzfs.c
-	${PYTHON} setup.py build
+build: libzfs.pyx ${PXIS} ${PXDS}
+	${PYTHON} -m pip install . --no-deps --no-build-isolation --target build/lib
 
 clean:
-	rm -rf build libzfs.c
+	rm -rf build dist libzfs.c *.egg-info
 
 install:
-	${PYTHON} setup.py install --prefix ${PREFIX}
+	${PYTHON} -m pip install . --no-deps --no-build-isolation --prefix ${PREFIX}

--- a/ci/run_in_container.sh
+++ b/ci/run_in_container.sh
@@ -797,6 +797,9 @@ case "${STEP}" in
 
     # Minimal import check
     build_dir=$(ls -d build/lib.* 2>/dev/null | head -n 1 || true)
+    if [[ -z "${build_dir}" && -d build/lib ]]; then
+      build_dir=build/lib
+    fi
     PYTHONPATH="${build_dir}${PYTHONPATH:+:$PYTHONPATH}" python3 - <<'PY'
 import libzfs
 print("libzfs import OK", libzfs.__name__)
@@ -818,16 +821,8 @@ PY
       tail -n 200 config.log || true
       exit 1
     fi
-    if python3 - <<'PY' >/dev/null 2>&1
-import sys
-raise SystemExit(0 if sys.version_info >= (3, 7) else 1)
-PY
-    then
-      ensure_python_build
-      python3 -m build --no-isolation --sdist --wheel
-    else
-      python3 setup.py sdist bdist_wheel
-    fi
+    ensure_python_build
+    python3 -m build --no-isolation --sdist --wheel
     build_system_packages
     ;;
 esac

--- a/packaging/rocky-el8/main.spec.j2
+++ b/packaging/rocky-el8/main.spec.j2
@@ -29,7 +29,9 @@ make
 
 %install
 echo "Starting install process..."
-python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+PIP_DISABLE_PIP_VERSION_CHECK=1 \
+PIP_ROOT_USER_ACTION=ignore \
+  python3 -m pip install . --no-deps --no-build-isolation --root=$RPM_BUILD_ROOT --prefix=/usr --record=INSTALLED_FILES
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/packaging/rocky-el9/main.spec.j2
+++ b/packaging/rocky-el9/main.spec.j2
@@ -29,7 +29,9 @@ make
 
 %install
 echo "Starting install process..."
-python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+PIP_DISABLE_PIP_VERSION_CHECK=1 \
+PIP_ROOT_USER_ACTION=ignore \
+  python3 -m pip install . --no-deps --no-build-isolation --root=$RPM_BUILD_ROOT --prefix=/usr --record=INSTALLED_FILES
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
### Motivation
- Modernize build and packaging flows to use `pip` and `python -m build` instead of calling `setup.py` directly to improve isolation and compatibility with recent Python packaging standards.

### Description
- Update `Makefile.in` to build into `build/lib` via `python -m pip install . --target build/lib` and to install via `python -m pip install .`, and expand the `clean` target to remove `dist` and `*.egg-info` artifacts.
- Adjust CI (`ci/run_in_container.sh`) to detect `build/lib` as the build output and to always use `ensure_python_build` followed by `python3 -m build --no-isolation --sdist --wheel` for packaging.
- Replace direct `python3 setup.py install` calls in RPM spec templates (`packaging/rocky-el8/main.spec.j2` and `packaging/rocky-el9/main.spec.j2`) with `python3 -m pip install .` and set `PIP_DISABLE_PIP_VERSION_CHECK`/`PIP_ROOT_USER_ACTION` environment variables for the RPM `%install` phase.

### Testing
- No automated tests or CI runs were executed for these changes (CI was not run in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968ec8948bc832eb851c23504241d94)