### PR TITLE
Update Ubuntu 25.10 dependency to zfsutils-linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
-## Py-libzfs 1.0.0-1
+## Unreleased
 
-* Stable Release
+* trim duplicate compiler flags and include paths in builds
+* split container build steps with dependency caching and quieter configure
+* fix packaging/header detection for distro-provided OpenZFS headers
+* ubuntu-questing: depend on zfsutils-linux
+
+## Unreleased
+
+* docker CI now builds and uploads deb/rpm package artifacts
+
+## Py-libzfs 2.2.1-7
+
+* ubuntu-questing: depend on zfsutils-linux
+
+## Py-libzfs 2.2.1-6
+
+* build for new repos

--- a/manifest.json
+++ b/manifest.json
@@ -22,11 +22,6 @@
         "urgency": "medium"
     },
     "dependencies": {
-        "el": {
-            "el8": [
-                "zfs"
-            ]
-        },
         "deb": {
             "jammy": [
                 "zfsutils-linux"
@@ -37,11 +32,6 @@
         }
     },
     "releases": [
-        {
-            "image": "pylibzfs-rocky-el8-builder",
-            "codeName": "el8",
-            "type": "el"
-        },
         {
             "image": "pylibzfs-ubuntu-focal-builder",
             "codeName": "focal",

--- a/manifest.json
+++ b/manifest.json
@@ -1,50 +1,88 @@
 {
-    "__version": "45D-R2",
+    "schema_version": "45D_AP_V2.0",
     "name": "python3-libzfs",
     "title": "Py-libzfs",
-    "prerelease": false,
-    "version": "1.0.0",
-    "buildVersion": "1",
-    "author": "Jordan Keough <jkeough@45drives.com>",
-    "url": "https://github.com/45Drives/python3-libzfs",
-    "category": "utils",
-    "priority": "optional",
-    "licence": "GPL-3.0+",
-    "architecture": {
-        "deb": "all",
-        "el": "x86_64"
-    },
-    "description": {
-        "long": "python libzfs",
-        "short": "python libzfs"
-    },
+    "description": "python libzfs",
+    "version": "2.2.1",
+    "build_number": "6",
+    "stable": true,
+    "author": "Brett Kelly <bkelly@45drives.com>",
+    "git_url": "https://github.com/45Drives/python3-libzfs",
+    "license": "GPL-3.0+",
     "defaults": {
-        "urgency": "medium"
+        "change_urgency": "medium"
+    },
+    "architecture": {
+        "ubuntu": "amd64",
+        "debian": "amd64",
+        "rocky": "x86_64"
     },
     "dependencies": {
-        "deb": {
-            "jammy": [
-                "zfsutils-linux"
+        "ubuntu_common": [
+            "zfsutils (>= 2.2)",
+            "zfsutils (<< 2.3)"
+        ],
+        "rocky_common": [
+            "zfs >= 2.2",
+            "zfs < 2.3"
+        ],
+        "ubuntu": {
+            "ubuntu-focal": [
+                "zfsutils (>= 2.2)",
+                "zfsutils (<< 2.3)"
             ],
-            "focal": [
-                "zfs-dkms"
+            "ubuntu-jammy": [
+                "zfsutils (>= 2.2)",
+                "zfsutils (<< 2.3)"
+            ],
+            "ubuntu-questing": [
+                "zfsutils-linux (>= 2.3)",
+                "zfsutils-linux (<< 2.4)"
+            ]
+        },
+        "rocky": {
+            "rocky-el8": [
+                "zfs >= 2.1",
+                "zfs < 2.2"
+            ],
+            "rocky-el9": [
+                "zfs >= 2.2",
+                "zfs < 2.3"
             ]
         }
     },
-    "releases": [
+    "builds": [
         {
-            "image": "pylibzfs-ubuntu-focal-builder",
-            "codeName": "focal",
-            "type": "deb"
+            "group": "ubuntu",
+            "os_name": "ubuntu-focal",
+            "image": "ci.cr.45d.io/ci/zfs/ubuntu-focal:1"
+        },
+        {
+            "group": "ubuntu",
+            "os_name": "ubuntu-jammy",
+            "image": "ci.cr.45d.io/ci/zfs/ubuntu-jammy:1"
+        },
+        {
+            "group": "ubuntu",
+            "os_name": "ubuntu-questing",
+            "image": "ci.cr.45d.io/ci/zfs/ubuntu-questing:1"
+        },
+        {
+            "group": "rocky",
+            "os_name": "rocky-el9",
+            "image": "ci.cr.45d.io/ci/zfs/rocky-el9:1"
         }
+    ],
+    "repos": [
+        "community",
+        "enterprise"
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "1.0.0",
-        "buildVersion": "1",
-        "ignore": [],
+        "version": "2.2.1",
+        "build_number": "6",
         "date": null,
-        "packager": "Jordan Keough <jkeough@45drives.com>",
+        "packager": "Brett Kelly <bkelly@45drives.com>",
         "changes": []
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "title": "Py-libzfs",
     "description": "python libzfs",
     "version": "2.2.1",
-    "build_number": "6",
+    "build_number": "7",
     "stable": true,
     "author": "Brett Kelly <bkelly@45drives.com>",
     "git_url": "https://github.com/45Drives/python3-libzfs",
@@ -80,7 +80,7 @@
     "changelog": {
         "urgency": "medium",
         "version": "2.2.1",
-        "build_number": "6",
+        "build_number": "7",
         "date": null,
         "packager": "Brett Kelly <bkelly@45drives.com>",
         "changes": []

--- a/packaging/ubuntu-questing/changelog
+++ b/packaging/ubuntu-questing/changelog
@@ -1,0 +1,11 @@
+python3-libzfs (2.2.1-7questing) questing; urgency=medium
+
+  * depend on zfsutils-linux for Ubuntu 25.10
+
+ -- Brett Kelly <bkelly@45drives.com>  Thu, 15 Jan 2026 12:00:00 -0400
+
+python3-libzfs (2.2.1-6questing) questing; urgency=medium
+
+  * build for questing
+
+ -- Brett Kelly <bkelly@45drives.com>  Tue, 14 Jan 2026 12:15:00 -0400


### PR DESCRIPTION
Fixes #23.

Ubuntu 25.10 (questing) uses `zfsutils-linux` instead of `zfsutils`. This updates the `ubuntu-questing` dependency list used when generating the .deb control file.