### PR TITLE
Ubuntu questing: depend on zfsutils-linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 * trim duplicate compiler flags and include paths in builds
 * split container build steps with dependency caching and quieter configure
 * fix packaging/header detection for distro-provided OpenZFS headers
+* ubuntu-questing: depend on zfsutils-linux
 
 ## Unreleased
 
 * docker CI now builds and uploads deb/rpm package artifacts
+
+## Py-libzfs 2.2.1-7
+
+* ubuntu-questing: depend on zfsutils-linux
 
 ## Py-libzfs 2.2.1-6
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "title": "Py-libzfs",
     "description": "python libzfs",
     "version": "2.2.1",
-    "build_number": "6",
+    "build_number": "7",
     "stable": true,
     "author": "Brett Kelly <bkelly@45drives.com>",
     "git_url": "https://github.com/45Drives/python3-libzfs",
@@ -36,8 +36,8 @@
                 "zfsutils (<< 2.3)"
             ],
             "ubuntu-questing": [
-                "zfsutils (>= 2.3)",
-                "zfsutils (<< 2.4)"
+                "zfsutils-linux (>= 2.3)",
+                "zfsutils-linux (<< 2.4)"
             ]
         },
         "rocky": {
@@ -80,7 +80,7 @@
     "changelog": {
         "urgency": "medium",
         "version": "2.2.1",
-        "build_number": "6",
+        "build_number": "7",
         "date": null,
         "packager": "Brett Kelly <bkelly@45drives.com>",
         "changes": []

--- a/packaging/ubuntu-questing/changelog
+++ b/packaging/ubuntu-questing/changelog
@@ -1,3 +1,9 @@
+python3-libzfs (2.2.1-7questing) questing; urgency=medium
+
+  * depend on zfsutils-linux for Ubuntu 25.10
+
+ -- Brett Kelly <bkelly@45drives.com>  Thu, 15 Jan 2026 18:30:00 -0400
+
 python3-libzfs (2.2.1-6questing) questing; urgency=medium
 
   * build for questing


### PR DESCRIPTION
Fixes #23.

Ubuntu 25.10 (questing) uses `zfsutils-linux` instead of `zfsutils`. This updates the questing packaging dependency accordingly (plus bumps build number/changelogs).